### PR TITLE
Remove `serverless-es-logs` plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "devDependencies": {
                 "aws-sso-creds-helper": "^1.8.15",
                 "serverless": "^3.21.0",
-                "serverless-es-logs": "^3.4.2",
                 "serverless-plugin-git-variables": "^5.2.0",
                 "serverless-prune-plugin": "^2.0.1",
                 "serverless-python-requirements": "^5.4.0",
@@ -4731,34 +4730,6 @@
                 "node": ">=12.0"
             }
         },
-        "node_modules/serverless-es-logs": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-            "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-            "dev": true,
-            "dependencies": {
-                "fs-extra": "9.0.0",
-                "lodash": "4.17.21"
-            },
-            "engines": {
-                "node": ">=10.0"
-            }
-        },
-        "node_modules/serverless-es-logs/node_modules/fs-extra": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-            "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-            "dev": true,
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/serverless-plugin-git-variables": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/serverless-plugin-git-variables/-/serverless-plugin-git-variables-5.2.0.tgz",
@@ -5436,15 +5407,6 @@
             "dev": true,
             "dependencies": {
                 "type": "^2.5.0"
-            }
-        },
-        "node_modules/universalify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-            "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/unpipe": {
@@ -9461,30 +9423,6 @@
                 "yaml-ast-parser": "0.0.43"
             }
         },
-        "serverless-es-logs": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-            "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-            "dev": true,
-            "requires": {
-                "fs-extra": "9.0.0",
-                "lodash": "4.17.21"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-                    "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-                    "dev": true,
-                    "requires": {
-                        "at-least-node": "^1.0.0",
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^6.0.1",
-                        "universalify": "^1.0.0"
-                    }
-                }
-            }
-        },
         "serverless-plugin-git-variables": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/serverless-plugin-git-variables/-/serverless-plugin-git-variables-5.2.0.tgz",
@@ -10028,12 +9966,6 @@
             "requires": {
                 "type": "^2.5.0"
             }
-        },
-        "universalify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-            "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "devDependencies": {
         "aws-sso-creds-helper": "^1.8.15",
         "serverless": "^3.21.0",
-        "serverless-es-logs": "^3.4.2",
         "serverless-plugin-git-variables": "^5.2.0",
         "serverless-prune-plugin": "^2.0.1",
         "serverless-python-requirements": "^5.4.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,7 +39,6 @@ provider:
     SERVICE_NAME: ${self:service}
 
 plugins:
-  - serverless-es-logs
   - serverless-plugin-git-variables
   - serverless-prune-plugin
   - serverless-python-requirements
@@ -70,10 +69,6 @@ custom:
   prune:
     automatic: true
     number: 3
-  esLogs:
-    endpoint: ${ssm:/dataplatform/shared/logs-elasticsearch-endpoint}
-    index: dataplatform-services
-    filterPattern: '{ $.function_name = "*" }'
   deploymentBucket:
     prod: ok-origo-dataplatform-config-prod
     dev: ok-origo-dataplatform-config-dev


### PR DESCRIPTION
The `serverless-es-logs` plugin has been replaced with our own logging solution. Also it ran on an obsoleted runtime blocking deployment.