### PR TITLE
Bump Node.js in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: '3.11'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox
         run: tox -e py,flake8,black
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version: '12.x'
+          node-version: '20.x'
       - name: Install NPM dependencies
         run: npm install
       - name: Deploy Lambda functions

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: '3.11'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox
         run: tox -e py,flake8,black
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version: '12.x'
+          node-version: '20.x'
       - name: Install NPM dependencies
         run: npm install
       - name: Deploy Lambda functions


### PR DESCRIPTION
Bump Node.js in GitHub Actions from version 12 to 20 to make the service deployable again.