### PR TITLE
Read client secret at runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.6.1
     # via okdata-sdk
-okdata-aws==2.1.0
+okdata-aws==2.2.0
     # via status-api (setup.py)
 okdata-resource-auth==0.1.4
     # via status-api (setup.py)

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,7 +34,6 @@ provider:
     RESOURCE_SERVER_CLIENT_ID: "okdata-resource-server"
     OKDATA_ENVIRONMENT: ${self:provider.stage}
     OKDATA_CLIENT_ID: status-api
-    OKDATA_CLIENT_SECRET: ${ssm:/dataplatform/status-api/keycloak-client-secret}
     SERVICE_NAME: ${self:service}
 
 plugins:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "aws-xray-sdk",
         "boto3",
-        "okdata-aws>=2,<3",
+        "okdata-aws>=2.2,<3",
         "okdata-resource-auth",
         "okdata-sdk>=2.4,<4",
         "requests",

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -1,7 +1,8 @@
 import json
-import pytest
 import re
+from unittest.mock import patch
 
+import pytest
 from okdata.aws.status import TraceStatus, TraceEventStatus
 from okdata.aws.status.sdk import Status
 
@@ -49,10 +50,11 @@ def test_send_event_with_succeeded_status(mocker):
     s = mocker.spy(Status, "add")
 
     trace_id = "trace-id-abc123-1a2b3c"
-    assert act_on_queue(
-        _make_event({"detail": {"status": "SUCCEEDED", "name": trace_id}}),
-        None,
-    )
+    with patch("event.handler.get_secret") as get_secret:
+        get_secret.return_value = "abc123"
+        assert act_on_queue(
+            _make_event({"detail": {"status": "SUCCEEDED", "name": trace_id}}), None
+        )
     assert (
         mocker.call(
             mocker.ANY,
@@ -72,9 +74,11 @@ def test_send_event_with_aborted_status(mocker):
     s = mocker.spy(Status, "add")
 
     trace_id = "trace-id-abc123-1a2b3c"
-    assert act_on_queue(
-        _make_event({"detail": {"status": "ABORTED", "name": trace_id}}), None
-    )
+    with patch("event.handler.get_secret") as get_secret:
+        get_secret.return_value = "abc123"
+        assert act_on_queue(
+            _make_event({"detail": {"status": "ABORTED", "name": trace_id}}), None
+        )
     assert (
         mocker.call(
             mocker.ANY,
@@ -94,7 +98,8 @@ def test_send_event_with_unknown_trace_id(requests_mock):
     requests_mock.register_uri("POST", matcher, status_code=404)
 
     trace_id = "trace-id-abc123-1a2b3c"
-    assert not act_on_queue(
-        _make_event({"detail": {"status": "SUCCEEDED", "name": trace_id}}),
-        None,
-    )
+    with patch("event.handler.get_secret") as get_secret:
+        get_secret.return_value = "abc123"
+        assert not act_on_queue(
+            _make_event({"detail": {"status": "SUCCEEDED", "name": trace_id}}), None
+        )


### PR DESCRIPTION
Read the Keycloak client secret from SSM at runtime instead of having it in the Lambda environment.