### PR TITLE
Ensure that `Decimal`s are sent to DynamoDB

### DIFF
--- a/status/create_status.py
+++ b/status/create_status.py
@@ -23,7 +23,7 @@ resource_authorizer = ResourceAuthorizer()
 @xray_recorder.capture("create_status")
 def handler(event, context):
     db = StatusData()
-    status_item = simplejson.loads(event["body"])
+    status_item = simplejson.loads(event["body"], use_decimal=True)
     try:
         bearer_token = extract_bearer_token(event)
         dataset_id = extract_dataset_id(status_item)

--- a/status/update_status.py
+++ b/status/update_status.py
@@ -22,7 +22,7 @@ def handler(event, context):
     trace_id = params["trace_id"]
     log_add(trace_id=trace_id)
 
-    content = simplejson.loads(event["body"])
+    content = simplejson.loads(event["body"], use_decimal=True)
 
     db = StatusData()
     result = db.get_status(trace_id)

--- a/test/test_statusdata.py
+++ b/test/test_statusdata.py
@@ -1,9 +1,12 @@
-import boto3
-import re
 import json
-import pytest
+import re
 from copy import deepcopy
-from moto import mock_dynamodb2
+from decimal import Decimal
+
+import boto3
+import pytest
+from moto import mock_aws
+
 from status.StatusData import StatusData
 
 event = {"pathParameters": {"trace_id": "uu-ii-dd"}, "body": json.dumps({})}
@@ -12,7 +15,7 @@ empty_context = {}
 
 @pytest.fixture()
 def dynamodb():
-    with mock_dynamodb2():
+    with mock_aws():
         yield boto3.resource("dynamodb", "eu-west-1")
 
 
@@ -59,6 +62,7 @@ status_body = {
     "trace_status": "OK",
     "trace_event_status": "STARTED",
     "errors": {"message": {"nb": "Problem", "en": "Problem"}},
+    "duration": Decimal("123.456"),
 }
 
 status_body_no_optional_data = {

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py311, flake8, black
 
 [testenv]
 deps =
-    moto[dynamodb]<4.0.0
+    moto[dynamodb]
     pytest
     pytest-mock
     requests_mock


### PR DESCRIPTION
DynamoDB doesn't eat raw float values. Ensure that floating point numbers are converted to `Decimal`s before feeding them to DynamoDB.