### PR TITLE
Upgrade okdata-aws to lose vulnerable dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,14 @@ botocore==1.27.21
     #   s3transfer
 certifi==2023.7.22
     # via requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==2.1.0
     # via requests
-ecdsa==0.17.0
-    # via python-jose
+cryptography==42.0.5
+    # via jwcrypto
+deprecation==2.1.0
+    # via python-keycloak
 idna==3.7
     # via
     #   anyio
@@ -35,31 +39,25 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.6.1
     # via okdata-sdk
-okdata-aws==2.2.0
+jwcrypto==1.5.6
+    # via python-keycloak
+okdata-aws==4.1.0
     # via status-api (setup.py)
 okdata-resource-auth==0.1.4
     # via status-api (setup.py)
-okdata-sdk==3.1.0
+okdata-sdk==3.1.1
     # via
     #   okdata-aws
     #   status-api (setup.py)
-pyasn1==0.4.8
-    # via
-    #   python-jose
-    #   rsa
-pydantic==1.10.13
-    # via okdata-aws
-pyjwt==2.4.0
-    # via okdata-sdk
+packaging==24.0
+    # via deprecation
+pycparser==2.22
+    # via cffi
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-jose==3.3.0
-    # via
-    #   okdata-sdk
-    #   python-keycloak
-python-keycloak==1.8.0
+python-keycloak==3.12.0
     # via okdata-sdk
 requests==2.31.0
     # via
@@ -67,30 +65,28 @@ requests==2.31.0
     #   okdata-resource-auth
     #   okdata-sdk
     #   python-keycloak
+    #   requests-toolbelt
     #   status-api (setup.py)
-rsa==4.8
-    # via python-jose
+requests-toolbelt==1.0.0
+    # via python-keycloak
 s3transfer==0.6.0
     # via boto3
 simplejson==3.17.2
     # via status-api (setup.py)
 six==1.16.0
-    # via
-    #   ecdsa
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.2.0
     # via anyio
-starlette==0.36.2
+starlette==0.37.2
     # via okdata-aws
 structlog==21.5.0
     # via okdata-aws
-typing-extensions==4.2.0
-    # via pydantic
+typing-extensions==4.11.0
+    # via jwcrypto
 urllib3==1.26.18
     # via
     #   botocore
     #   okdata-sdk
-    #   python-keycloak
     #   requests
 wrapt==1.14.1
     # via aws-xray-sdk

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "aws-xray-sdk",
         "boto3",
-        "okdata-aws>=2.2,<3",
+        "okdata-aws>=4.1",
         "okdata-resource-auth",
         "okdata-sdk>=2.4,<4",
         "requests",


### PR DESCRIPTION
Remove dependency on the vulnerable ecdsa library by upgrading okdata-aws.