### PR TITLE
Remove reference to `incoming`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,25 @@ Database is setup in
 
 The main fields in the database:
 
-| Field              | Type           | Description                                                                                           | Example                                               |
-| -----------        | -------------- | -----------                                                                                           | -----------                                           |
-| trace_id           | string         | The ID used to trace connected events throughout the system (N-entries). ***Primary partition key***. | `my-dataset-uu-ii-dd`                                 |
-| trace_event_id     | uuid           | Unique ID per event (many `trace_event_id` per `trace_id`).                                           | `uu-ii-dd`                                            |
-| domain             | string         | The domain that this status pertains to, e.g. `dataset` for publishing data or events to a dataset    | `dataset`                                             |
-| domain_id          | string         | A domain specific ID to be able to look up the owner or source. Includes version number.              | `dataset.name/version`                                |
-| start_time         | time           | Start of execution. ***Primary sort key***.                                                           | `2020-03-02T12:34:23.042400`                          |
-| end_time           | time           | End of execution                                                                                      | `2020-03-02T12:34:24.042400`                          |
-| trace_status       | string         | Overall status for the trace ID.                                                                      | `CONTINUE`, `FINISHED`                                |
-| trace_event_status | string         | Status for the `trace_event_id`.                                                                      | `OK`, `FAILED`                                        |
-| user               | string         | The user that is used in `handler` to execute the event                                               | `service-user-s3-writer`, `ooo123456`                 |
-| component          | string         | The component that is the source of the event.                                                        | `data-uploader`, `s3-writer`                          |
-| operation          | string         | The operation (e.g. method) performed by the component, e.g. Lambda function name                     | `copy`                                                |
-| status_body        | object         | Namespace where the component can add data relevant for the execution.                                | `{"files_incoming": [], "files_outgoing": []}`        |
-| meta               | object         | Metadata about the execution, such as Git revision of the component.                                  | `{"git_rev": ...}`                                    |
-| s3_path            | string         | Path of the uploaded file.                                                                            | `incoming/yellow/my-dataset/version/edition/file.xls` |
-| duration           | number         | Duration of execution in milliseconds.                                                                | `123`                                                 |
-| exception          | object         | Details of exception that has occurred.                                                               | `ZeroDivisionError: division by zero`                 |
-| errors             | object         | Error messages to be read by the end user.                                                            | `[{"message": {"nb": "", "en": ""}, ...]`             |
+| Field              | Type           | Description                                                                                           | Example                                          |
+| -----------        | -------------- | -----------                                                                                           | -----------                                      |
+| trace_id           | string         | The ID used to trace connected events throughout the system (N-entries). ***Primary partition key***. | `my-dataset-uu-ii-dd`                            |
+| trace_event_id     | uuid           | Unique ID per event (many `trace_event_id` per `trace_id`).                                           | `uu-ii-dd`                                       |
+| domain             | string         | The domain that this status pertains to, e.g. `dataset` for publishing data or events to a dataset    | `dataset`                                        |
+| domain_id          | string         | A domain specific ID to be able to look up the owner or source. Includes version number.              | `dataset.name/version`                           |
+| start_time         | time           | Start of execution. ***Primary sort key***.                                                           | `2020-03-02T12:34:23.042400`                     |
+| end_time           | time           | End of execution                                                                                      | `2020-03-02T12:34:24.042400`                     |
+| trace_status       | string         | Overall status for the trace ID.                                                                      | `CONTINUE`, `FINISHED`                           |
+| trace_event_status | string         | Status for the `trace_event_id`.                                                                      | `OK`, `FAILED`                                   |
+| user               | string         | The user that is used in `handler` to execute the event                                               | `service-user-s3-writer`, `ooo123456`            |
+| component          | string         | The component that is the source of the event.                                                        | `data-uploader`, `s3-writer`                     |
+| operation          | string         | The operation (e.g. method) performed by the component, e.g. Lambda function name                     | `copy`                                           |
+| status_body        | object         | Namespace where the component can add data relevant for the execution.                                | `{"files_incoming": [], "files_outgoing": []}`   |
+| meta               | object         | Metadata about the execution, such as Git revision of the component.                                  | `{"git_rev": ...}`                               |
+| s3_path            | string         | Path of the uploaded file.                                                                            | `raw/yellow/my-dataset/version/edition/file.xls` |
+| duration           | number         | Duration of execution in milliseconds.                                                                | `123`                                            |
+| exception          | object         | Details of exception that has occurred.                                                               | `ZeroDivisionError: division by zero`            |
+| errors             | object         | Error messages to be read by the end user.                                                            | `[{"message": {"nb": "", "en": ""}, ...]`        |
 
 **Note**: While the `trace_event_id` is unique to each event (row), the
 `trace_id` is only unique to a *group of connected events* ("a trace").


### PR DESCRIPTION
The `incoming` S3 path was renamed to `raw` in 2020. Remove the remaining reference to the old name.